### PR TITLE
expandtoexfat.sh: Suppress timestamp-related error messages

### DIFF
--- a/sh/expandtoexfat.sh
+++ b/sh/expandtoexfat.sh
@@ -54,7 +54,7 @@ printf "t\n3\n7\nw\n" | sudo fdisk /dev/mmcblk0
 sudo mount -t exfat -w /dev/mmcblk0p3 /roms
 exitcode=$?
 sleep 2
-sudo tar -xvf /roms.tar -C /
+sudo tar -xvf --warning=no-timestamp /roms.tar -C /
 sync
 sudo rm -rf -v /roms/themes/es-theme-nes-box/
 # Setup swapfile


### PR DESCRIPTION
The console we're installing to may have an incorrect clock at the time of install, which if it is the case, will be very far in the past compared to the timestamps of the OS contents. This could lead to the `expandtoexfat.sh` script becoming bottlenecked by the framebuffer if it has to write a very large volume of logs noting that `roms.tar`'s timestamps are from a point in time ahead of what the console's clock is set to.  We can append a flag to disable timestamp warnings to the tar call in the `expandtoexfat.sh` scripts to reduce unnecessary log writing to the display.