### PR TITLE
update `build_update_tar.sh` and `clone_support.sh`

### DIFF
--- a/build_update_tar.sh
+++ b/build_update_tar.sh
@@ -79,9 +79,8 @@ rsync $RSYNC_BOOT_OPTS --exclude='files' ./consoles/ "$PAYLOAD_BOOT/consoles/"
 cp -f ./sh/clone.sh "$PAYLOAD_BOOT/firstboot.sh"
 
 # 其他 boot 工具保持原文件名
-cp -f ./dtb_selector_macos_intel \
+cp -f ./dtb_selector_macos \
       ./dtb_selector_win32.exe \
-      ./dtb_selector_macos_apple \
       ./sh/expandtoexfat.sh \
       "$PAYLOAD_BOOT/" 2>/dev/null || true
 

--- a/clone_support.sh
+++ b/clone_support.sh
@@ -17,7 +17,7 @@ sudo mkdir -p "$MOUNT_DIR/boot/consoles"
 sudo rsync $RSYNC_BOOT_OPTS --exclude='files' ./consoles/ "$MOUNT_DIR/boot/consoles/"
 
 # 这些都是普通文件，直接复制即可
-sudo cp -f ./sh/clone.sh ./dtb_selector_macos_intel ./dtb_selector_win32.exe ./dtb_selector_macos_apple ./sh/expandtoexfat.sh "$MOUNT_DIR/boot/"
+sudo cp -f ./sh/clone.sh ./dtb_selector_macos ./dtb_selector_win32.exe ./sh/expandtoexfat.sh "$MOUNT_DIR/boot/"
 
 echo "== 注入按键信息 =="
 sudo mkdir -p "$MOUNT_DIR/root/home/ark/.quirks"


### PR DESCRIPTION
Update `build_update_tar.sh` and `clone_support.sh` to copy only `dtb_selector_win32.exe` and `dtb_selector_macos`