### PR TITLE
Fix missing PPSSPP 2021 backup configuration in R3XS builds

### DIFF
--- a/sh/clone.sh
+++ b/sh/clone.sh
@@ -427,11 +427,14 @@ main() {
   # The R3XS build does not ship with a default backup configuration for
   # PPSSPP 2021. Without it, configuration changes are not persisted.
   # Copy the default backup configuration if it is missing.
-  if [[ -d "/opt/ppsspp/backupforromsfolder/ppsspp" ]] && \
-     [[ ! -d "/opt/ppsspp-2021/backupforromsfolder/ppsspp" ]]; then
-      sudo mkdir -p /opt/ppsspp-2021/backupforromsfolder
-      sudo cp -a /opt/ppsspp/backupforromsfolder/ppsspp \
-          /opt/ppsspp-2021/backupforromsfolder/
+  if [[ -d "/opt/ppsspp/backupforromsfolder/ppsspp" ]]; then
+    if [[ ! -d "/opt/ppsspp-2021/backupforromsfolder/ppsspp" ]]; then
+        sudo mkdir -p /opt/ppsspp-2021/backupforromsfolder
+        sudo cp -a /opt/ppsspp/backupforromsfolder/ppsspp \
+            /opt/ppsspp-2021/backupforromsfolder/
+    fi
+
+    sudo chown -R ark:ark /opt/ppsspp-2021/backupforromsfolder
   fi
 
   # 驱动加载

--- a/sh/clone.sh
+++ b/sh/clone.sh
@@ -423,6 +423,17 @@ main() {
     msg "Console unchanged: $cur_val"
   fi
 
+  # Fix for PPSSPP 2021 standalone:
+  # The R3XS build does not ship with a default backup configuration for
+  # PPSSPP 2021. Without it, configuration changes are not persisted.
+  # Copy the default backup configuration if it is missing.
+  if [[ -d "/opt/ppsspp/backupforromsfolder/ppsspp" ]] && \
+     [[ ! -d "/opt/ppsspp-2021/backupforromsfolder/ppsspp" ]]; then
+      sudo mkdir -p /opt/ppsspp-2021/backupforromsfolder
+      sudo cp -a /opt/ppsspp/backupforromsfolder/ppsspp \
+          /opt/ppsspp-2021/backupforromsfolder/
+  fi
+
   # 驱动加载
   sudo depmod -a 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

My last R3XS build did not include the default backup configuration for the PPSSPP 2021 standalone under:

/opt/ppsspp-2021/backupforromsfolder/ppsspp

Without this directory, changes made from within PPSSPP 2021 (such as controller mappings and emulator settings) are not persisted across launches.

## Changes

- Check whether the PPSSPP 2021 backup configuration exists.
- If it is missing and the standard PPSSPP backup configuration is available, copy it to the PPSSPP 2021 location.
- The copy only occurs once and does not overwrite an existing configuration.

This ensures new ArkOS4Clone installations have a working default backup configuration while preserving any existing user configuration.